### PR TITLE
Updated rest client to work with ruby 2.4.x

### DIFF
--- a/mundipagg_sdk.gemspec
+++ b/mundipagg_sdk.gemspec
@@ -2,13 +2,13 @@ Gem::Specification.new do |s|
   s.name = 'mundipagg_sdk'
   s.summary = 'MundiPagg Ruby Client Library'
   s.description = 'Ruby library for integrating with the MundiPagg payment web services'
-  s.version = '1.4.1' # Major.Minor.Revision
+  s.version = '1.4.2' # Major.Minor.Revision
   s.author = 'MundiPagg'
   s.email = 'github@mundipagg.com'
   s.homepage = 'http://www.mundipagg.com/'
   s.files = Dir.glob ["README.md", "LICENSE", "lib/**/*.{rb}", "*.gemspec"]
   s.test_files = Dir.glob ["spec/**/*"]
-  s.add_dependency 'rest-client', '~> 1.8', '>= 1.8.0'
+  s.add_dependency 'rest-client', '~> 2.0', '>= 2.0.1'
   s.add_dependency 'nori', '~> 2.6', '>= 2.6.0'
   s.add_dependency 'gyoku', '~> 1.3', '>= 1.3.1'
   s.add_dependency 'nokogiri', '~> 1.6', '>= 1.6.6.2'


### PR DESCRIPTION
Using the gem I start to receive an error on ruby 2.4.5:

> KeyError (key not found: :ciphers):
> app/services/checkout/credit_card_transaction.rb:42:in `send_transaction_to_mundipagg'

read more: https://github.com/rest-client/rest-client/issues/612